### PR TITLE
Fix binary_provider_cache_maxsize parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,7 +41,7 @@ class artifactory_pro(
     binary_provider_type           => $binary_provider_type,
     pool_max_active                => $pool_max_active,
     pool_max_idle                  => $pool_max_idle,
-    binary_provider_cache_maxSize  => $binary_provider_cache_maxsize,
+    binary_provider_cache_maxsize  => $binary_provider_cache_maxsize,
     binary_provider_filesystem_dir => $binary_provider_filesystem_dir,
     binary_provider_cache_dir      => $binary_provider_cache_dir,
     jdbc_driver_url                => $jdbc_driver_url,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@
 
 class artifactory_pro(
   String $license_key,
+  Boolean $manage_java                                                    = true,
   String $yum_name                                                        = 'bintray-jfrog-artifactory-pro-rpms',
   String $yum_baseurl                                                     = 'http://jfrog.bintray.com/artifactory-pro-rpms',
   String $package_name                                                    = 'jfrog-artifactory-pro',
@@ -31,6 +32,7 @@ class artifactory_pro(
 ) {
 
   class{'::artifactory':
+    manage_java                    => $manage_java,
     yum_name                       => $yum_name,
     yum_baseurl                    => $yum_baseurl,
     package_name                   => $package_name,

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "autostructure-artifactory",
-      "version_requirement": ">= 2.0.0"
+      "version_requirement": ">= 2.0.9"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Base module `autostructure-artifactory` updated the parameter name
`binary_provider_cache_maxSize` to `binary_provider_cache_maxsize` in
version 2.0.9

Also expose the `manage_java` parameter.